### PR TITLE
[mod] use quad9 dns for connectivity checks when lxc

### DIFF
--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -556,7 +556,7 @@ EOF
 check_connectivity() {
     local ret_val=0
     info_msg "check internet connectivity ..."
-    if ! lxc exec "${1}" -- ping -c 1 8.8.8.8 &>/dev/null; then
+    if ! lxc exec "${1}" -- ping -c 1 9.9.9.9 &>/dev/null; then
         ret_val=1
         err_msg "no internet connectivity!"
         info_msg "Most often the connectivity is blocked by a docker installation:"


### PR DESCRIPTION
## What does this PR do?
Change IP to check when checking for connectivity in lxc to quad9.
https://www.quad9.net/about/
https://bgp.tools/as/42#whois
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
Don't ping quad8.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
`ping -c 1 9.9.9.9`
<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist
N/A
<!-- additional notes for reviewers -->

## Related issues
N/A
<!--
Closes #234
-->
